### PR TITLE
Wheel extra support

### DIFF
--- a/src/_wheel2deb/context.py
+++ b/src/_wheel2deb/context.py
@@ -17,6 +17,7 @@ class Context:
     ignore_entry_points = attr.ib(default=False)
     ignore_upstream_versions = attr.ib(default=False)
     ignore_requirements = attr.ib(factory=list)
+    extra = attr.ib(default='')
     map = attr.ib(factory=dict)
     depends = attr.ib(factory=list)
     provides = attr.ib(factory=list)

--- a/src/_wheel2deb/depends.py
+++ b/src/_wheel2deb/depends.py
@@ -83,7 +83,7 @@ def search_python_deps(ctx, wheel, extras=None):
 
     # keep only requirements that match the environment
     # https://www.python.org/dev/peps/pep-0508/#environment-markers
-    requirements = wheel.run_requires(ctx.python_version)
+    requirements = wheel.run_requires(ctx.python_version, ctx.extra)
 
     # filter out ignored requirements
     def is_required(r):

--- a/src/_wheel2deb/pydist.py
+++ b/src/_wheel2deb/pydist.py
@@ -111,9 +111,8 @@ class Wheel:
             req.name = normalize_name(req.name)
         return reqs
 
-    @lru_cache(maxsize=None)
-    def run_requires(self, pyvers):
-        env = {'python_version': str(pyvers)}
+    def run_requires(self, pyvers, wheel_extra):
+        env = {'python_version': str(pyvers), 'extra': str(wheel_extra)}
         return self.requires(env)
 
     @lru_cache(maxsize=None)

--- a/wheel2deb.example.yml
+++ b/wheel2deb.example.yml
@@ -1,0 +1,12 @@
+# change setting for all wheels
+.:
+  maintainer_name: "Me"
+  maintainer_email: "me@example.com"
+
+# ignore entrypoints of a wheel
+cffi:
+  ignore_entry_points: True
+
+# add an extra to a wheel
+docker:
+  extra: ssh


### PR DESCRIPTION
I wanted to compile the docker python package with ssh support. With ``pip3`` you would install it like ``pip3 install docker[ssh]``.

This PR adds a config option to force enable one extra for a package.